### PR TITLE
fix: fix name of repository class

### DIFF
--- a/app/Conversions.php
+++ b/app/Conversions.php
@@ -6,18 +6,16 @@ namespace App;
 use App\Models\Conversions as ConversionsModel;
 use App\FixerClient as Client;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
-use \Exception;
 
 class Conversions
 {
     public function __construct(
         private Client $client,
-        private CurrencyRepository $repository
+        private ConversionsRepository $repository
     )
     {
         $this->client = new Client();
-        $this->repository = new CurrencyRepository(new ConversionsModel());
+        $this->repository = new ConversionsRepository(new ConversionsModel());
     }
 
     public function processCurrencyConversion(Request $request): ConversionsModel

--- a/app/ConversionsRepository.php
+++ b/app/ConversionsRepository.php
@@ -7,7 +7,7 @@ use App\Models\Conversions as ConversionsModel;
 use \Exception;
 use \stdClass;
 
-class CurrencyRepository
+class ConversionsRepository
 {
     public function __construct (
         private ConversionsModel $conversionsModel


### PR DESCRIPTION
This PR is meant to fix the name of the ConversionsRepository class.