### PR TITLE
feat: add key generate instructions for Laravel Sail

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ FIXER_API_KEY=
 
 ### How to create the database?
 
-Once the container was created and running, you have to run the following command: `./vendor/bin/sail artisan migrate:fresh`.
+Once the container was created and running, you have to run the following commands: 
+```
+./vendor/bin/sail artisan key:generate;
+./vendor/bin/sail artisan migrate:fresh;
+```.
 
 ### How to access the API?
 


### PR DESCRIPTION
This PR is meant to add further instructions for the `key:generate` command using Laravel Sail.