### PR TITLE
feat: add support for rate and timestamp fields on conversions schema

### DIFF
--- a/database/migrations/2021_03_13_235528_alter_conversions_table_add_rate_and_timestamp_fields.php
+++ b/database/migrations/2021_03_13_235528_alter_conversions_table_add_rate_and_timestamp_fields.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AlterConversionsTableAddRateAndTimestampFields extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('conversions', function (Blueprint $table) {
+            $table->text('rate')->after('value');
+            $table->timestamp('timestamp')->after('rate');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('conversions', function (Blueprint $table) {
+            $table->dropColumn('timestamp');
+            $table->dropColumn('rate');
+        });
+    }
+}


### PR DESCRIPTION
This PR is meant to add support for rate and timestamp fields on the conversions table.