### PR TITLE
feat: add support for rate and timestamp fields on conversions schema

### DIFF
--- a/app/ConversionRepository.php
+++ b/app/ConversionRepository.php
@@ -21,6 +21,8 @@ class ConversionRepository
         $this->model['target_currency'] = $currencyConvertedResponse->query->to;
         $this->model['value'] = (string) $currencyConvertedResponse->query->amount;
         $this->model['amount_converted'] = (string) $currencyConvertedResponse->result;
+        $this->model['rate'] = (string) $currencyConvertedResponse->info->rate;
+        $this->model['timestamp'] = (string) $currencyConvertedResponse->info->timestamp;
 
         if (!$this->model->save()) {
             throw new Exception('Conversion was not recorded.');

--- a/database/migrations/2021_03_13_235528_alter_conversions_table_add_rate_and_timestamp_fields.php
+++ b/database/migrations/2021_03_13_235528_alter_conversions_table_add_rate_and_timestamp_fields.php
@@ -15,7 +15,7 @@ class AlterConversionsTableAddRateAndTimestampFields extends Migration
     {
         Schema::table('conversions', function (Blueprint $table) {
             $table->text('rate')->after('value');
-            $table->timestamp('timestamp')->after('rate');
+            $table->text('timestamp')->after('rate');
         });
     }
 


### PR DESCRIPTION
This PR is meant to add support for rate and timestamp fields into the database and the API response.